### PR TITLE
Implement Signalwithstart

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,5 +79,3 @@ jobs:
 
       - name: Run E2E tests
         run: uv run pytest tests/e2e -v --tb=short -m e2e
-        env:
-          FLOVYN_SERVER_IMAGE: rg.fr-par.scw.cloud/flovyn/flovyn-server:latest

--- a/flovyn/_native/flovyn_worker_ffi.py
+++ b/flovyn/_native/flovyn_worker_ffi.py
@@ -468,6 +468,10 @@ def _uniffi_check_api_checksums(lib):
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_flovyn_worker_ffi_checksum_method_coreclient_resolve_promise() != 56407:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    if lib.uniffi_flovyn_worker_ffi_checksum_method_coreclient_signal_with_start_workflow() != 57504:
+        raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    if lib.uniffi_flovyn_worker_ffi_checksum_method_coreclient_signal_workflow() != 6467:
+        raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_flovyn_worker_ffi_checksum_method_coreclient_start_workflow() != 16527:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_flovyn_worker_ffi_checksum_method_coreworker_complete_task() != 65396:
@@ -552,9 +556,15 @@ def _uniffi_check_api_checksums(lib):
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_flovyn_worker_ffi_checksum_method_ffiworkflowcontext_current_time_millis() != 38125:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    if lib.uniffi_flovyn_worker_ffi_checksum_method_ffiworkflowcontext_drain_signals() != 26519:
+        raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_flovyn_worker_ffi_checksum_method_ffiworkflowcontext_get_state() != 9129:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    if lib.uniffi_flovyn_worker_ffi_checksum_method_ffiworkflowcontext_has_signal() != 27653:
+        raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_flovyn_worker_ffi_checksum_method_ffiworkflowcontext_is_cancellation_requested() != 18572:
+        raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    if lib.uniffi_flovyn_worker_ffi_checksum_method_ffiworkflowcontext_pending_signal_count() != 13337:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_flovyn_worker_ffi_checksum_method_ffiworkflowcontext_random() != 22015:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
@@ -577,6 +587,8 @@ def _uniffi_check_api_checksums(lib):
     if lib.uniffi_flovyn_worker_ffi_checksum_method_ffiworkflowcontext_state_keys() != 6962:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_flovyn_worker_ffi_checksum_method_ffiworkflowcontext_take_commands() != 63915:
+        raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    if lib.uniffi_flovyn_worker_ffi_checksum_method_ffiworkflowcontext_wait_for_signal() != 4847:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_flovyn_worker_ffi_checksum_method_ffiworkflowcontext_workflow_execution_id() != 54462:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
@@ -733,6 +745,25 @@ _UniffiLib.uniffi_flovyn_worker_ffi_fn_method_coreclient_resolve_promise.argtype
     ctypes.POINTER(_UniffiRustCallStatus),
 )
 _UniffiLib.uniffi_flovyn_worker_ffi_fn_method_coreclient_resolve_promise.restype = None
+_UniffiLib.uniffi_flovyn_worker_ffi_fn_method_coreclient_signal_with_start_workflow.argtypes = (
+    ctypes.c_void_p,
+    _UniffiRustBuffer,
+    _UniffiRustBuffer,
+    _UniffiRustBuffer,
+    _UniffiRustBuffer,
+    _UniffiRustBuffer,
+    _UniffiRustBuffer,
+    ctypes.POINTER(_UniffiRustCallStatus),
+)
+_UniffiLib.uniffi_flovyn_worker_ffi_fn_method_coreclient_signal_with_start_workflow.restype = _UniffiRustBuffer
+_UniffiLib.uniffi_flovyn_worker_ffi_fn_method_coreclient_signal_workflow.argtypes = (
+    ctypes.c_void_p,
+    _UniffiRustBuffer,
+    _UniffiRustBuffer,
+    _UniffiRustBuffer,
+    ctypes.POINTER(_UniffiRustCallStatus),
+)
+_UniffiLib.uniffi_flovyn_worker_ffi_fn_method_coreclient_signal_workflow.restype = _UniffiRustBuffer
 _UniffiLib.uniffi_flovyn_worker_ffi_fn_method_coreclient_start_workflow.argtypes = (
     ctypes.c_void_p,
     _UniffiRustBuffer,
@@ -997,17 +1028,32 @@ _UniffiLib.uniffi_flovyn_worker_ffi_fn_method_ffiworkflowcontext_current_time_mi
     ctypes.POINTER(_UniffiRustCallStatus),
 )
 _UniffiLib.uniffi_flovyn_worker_ffi_fn_method_ffiworkflowcontext_current_time_millis.restype = ctypes.c_int64
+_UniffiLib.uniffi_flovyn_worker_ffi_fn_method_ffiworkflowcontext_drain_signals.argtypes = (
+    ctypes.c_void_p,
+    ctypes.POINTER(_UniffiRustCallStatus),
+)
+_UniffiLib.uniffi_flovyn_worker_ffi_fn_method_ffiworkflowcontext_drain_signals.restype = _UniffiRustBuffer
 _UniffiLib.uniffi_flovyn_worker_ffi_fn_method_ffiworkflowcontext_get_state.argtypes = (
     ctypes.c_void_p,
     _UniffiRustBuffer,
     ctypes.POINTER(_UniffiRustCallStatus),
 )
 _UniffiLib.uniffi_flovyn_worker_ffi_fn_method_ffiworkflowcontext_get_state.restype = _UniffiRustBuffer
+_UniffiLib.uniffi_flovyn_worker_ffi_fn_method_ffiworkflowcontext_has_signal.argtypes = (
+    ctypes.c_void_p,
+    ctypes.POINTER(_UniffiRustCallStatus),
+)
+_UniffiLib.uniffi_flovyn_worker_ffi_fn_method_ffiworkflowcontext_has_signal.restype = ctypes.c_int8
 _UniffiLib.uniffi_flovyn_worker_ffi_fn_method_ffiworkflowcontext_is_cancellation_requested.argtypes = (
     ctypes.c_void_p,
     ctypes.POINTER(_UniffiRustCallStatus),
 )
 _UniffiLib.uniffi_flovyn_worker_ffi_fn_method_ffiworkflowcontext_is_cancellation_requested.restype = ctypes.c_int8
+_UniffiLib.uniffi_flovyn_worker_ffi_fn_method_ffiworkflowcontext_pending_signal_count.argtypes = (
+    ctypes.c_void_p,
+    ctypes.POINTER(_UniffiRustCallStatus),
+)
+_UniffiLib.uniffi_flovyn_worker_ffi_fn_method_ffiworkflowcontext_pending_signal_count.restype = ctypes.c_uint32
 _UniffiLib.uniffi_flovyn_worker_ffi_fn_method_ffiworkflowcontext_random.argtypes = (
     ctypes.c_void_p,
     ctypes.POINTER(_UniffiRustCallStatus),
@@ -1078,6 +1124,11 @@ _UniffiLib.uniffi_flovyn_worker_ffi_fn_method_ffiworkflowcontext_take_commands.a
     ctypes.POINTER(_UniffiRustCallStatus),
 )
 _UniffiLib.uniffi_flovyn_worker_ffi_fn_method_ffiworkflowcontext_take_commands.restype = _UniffiRustBuffer
+_UniffiLib.uniffi_flovyn_worker_ffi_fn_method_ffiworkflowcontext_wait_for_signal.argtypes = (
+    ctypes.c_void_p,
+    ctypes.POINTER(_UniffiRustCallStatus),
+)
+_UniffiLib.uniffi_flovyn_worker_ffi_fn_method_ffiworkflowcontext_wait_for_signal.restype = _UniffiRustBuffer
 _UniffiLib.uniffi_flovyn_worker_ffi_fn_method_ffiworkflowcontext_workflow_execution_id.argtypes = (
     ctypes.c_void_p,
     ctypes.POINTER(_UniffiRustCallStatus),
@@ -1363,6 +1414,12 @@ _UniffiLib.uniffi_flovyn_worker_ffi_checksum_method_coreclient_reject_promise.re
 _UniffiLib.uniffi_flovyn_worker_ffi_checksum_method_coreclient_resolve_promise.argtypes = (
 )
 _UniffiLib.uniffi_flovyn_worker_ffi_checksum_method_coreclient_resolve_promise.restype = ctypes.c_uint16
+_UniffiLib.uniffi_flovyn_worker_ffi_checksum_method_coreclient_signal_with_start_workflow.argtypes = (
+)
+_UniffiLib.uniffi_flovyn_worker_ffi_checksum_method_coreclient_signal_with_start_workflow.restype = ctypes.c_uint16
+_UniffiLib.uniffi_flovyn_worker_ffi_checksum_method_coreclient_signal_workflow.argtypes = (
+)
+_UniffiLib.uniffi_flovyn_worker_ffi_checksum_method_coreclient_signal_workflow.restype = ctypes.c_uint16
 _UniffiLib.uniffi_flovyn_worker_ffi_checksum_method_coreclient_start_workflow.argtypes = (
 )
 _UniffiLib.uniffi_flovyn_worker_ffi_checksum_method_coreclient_start_workflow.restype = ctypes.c_uint16
@@ -1489,12 +1546,21 @@ _UniffiLib.uniffi_flovyn_worker_ffi_checksum_method_ffiworkflowcontext_create_pr
 _UniffiLib.uniffi_flovyn_worker_ffi_checksum_method_ffiworkflowcontext_current_time_millis.argtypes = (
 )
 _UniffiLib.uniffi_flovyn_worker_ffi_checksum_method_ffiworkflowcontext_current_time_millis.restype = ctypes.c_uint16
+_UniffiLib.uniffi_flovyn_worker_ffi_checksum_method_ffiworkflowcontext_drain_signals.argtypes = (
+)
+_UniffiLib.uniffi_flovyn_worker_ffi_checksum_method_ffiworkflowcontext_drain_signals.restype = ctypes.c_uint16
 _UniffiLib.uniffi_flovyn_worker_ffi_checksum_method_ffiworkflowcontext_get_state.argtypes = (
 )
 _UniffiLib.uniffi_flovyn_worker_ffi_checksum_method_ffiworkflowcontext_get_state.restype = ctypes.c_uint16
+_UniffiLib.uniffi_flovyn_worker_ffi_checksum_method_ffiworkflowcontext_has_signal.argtypes = (
+)
+_UniffiLib.uniffi_flovyn_worker_ffi_checksum_method_ffiworkflowcontext_has_signal.restype = ctypes.c_uint16
 _UniffiLib.uniffi_flovyn_worker_ffi_checksum_method_ffiworkflowcontext_is_cancellation_requested.argtypes = (
 )
 _UniffiLib.uniffi_flovyn_worker_ffi_checksum_method_ffiworkflowcontext_is_cancellation_requested.restype = ctypes.c_uint16
+_UniffiLib.uniffi_flovyn_worker_ffi_checksum_method_ffiworkflowcontext_pending_signal_count.argtypes = (
+)
+_UniffiLib.uniffi_flovyn_worker_ffi_checksum_method_ffiworkflowcontext_pending_signal_count.restype = ctypes.c_uint16
 _UniffiLib.uniffi_flovyn_worker_ffi_checksum_method_ffiworkflowcontext_random.argtypes = (
 )
 _UniffiLib.uniffi_flovyn_worker_ffi_checksum_method_ffiworkflowcontext_random.restype = ctypes.c_uint16
@@ -1528,6 +1594,9 @@ _UniffiLib.uniffi_flovyn_worker_ffi_checksum_method_ffiworkflowcontext_state_key
 _UniffiLib.uniffi_flovyn_worker_ffi_checksum_method_ffiworkflowcontext_take_commands.argtypes = (
 )
 _UniffiLib.uniffi_flovyn_worker_ffi_checksum_method_ffiworkflowcontext_take_commands.restype = ctypes.c_uint16
+_UniffiLib.uniffi_flovyn_worker_ffi_checksum_method_ffiworkflowcontext_wait_for_signal.argtypes = (
+)
+_UniffiLib.uniffi_flovyn_worker_ffi_checksum_method_ffiworkflowcontext_wait_for_signal.restype = ctypes.c_uint16
 _UniffiLib.uniffi_flovyn_worker_ffi_checksum_method_ffiworkflowcontext_workflow_execution_id.argtypes = (
 )
 _UniffiLib.uniffi_flovyn_worker_ffi_checksum_method_ffiworkflowcontext_workflow_execution_id.restype = ctypes.c_uint16
@@ -1746,6 +1815,41 @@ class CoreClientProtocol(typing.Protocol):
         """
 
         raise NotImplementedError
+    def signal_with_start_workflow(self, workflow_id: "str",workflow_kind: "str",workflow_input: "bytes",queue: "typing.Optional[str]",signal_name: "str",signal_value: "bytes"):
+        """
+        Send a signal to an existing workflow, or create a new workflow and send the signal.
+
+        This is an atomic operation - either the workflow exists and receives the signal,
+        or a new workflow is created with the signal. This prevents race conditions
+        where a workflow might be created between checking for existence and signaling.
+
+        # Arguments
+        * `workflow_id` - The workflow ID (used as idempotency key)
+        * `workflow_kind` - The type/kind of workflow to create if it doesn't exist
+        * `workflow_input` - Serialized input for the workflow (JSON bytes)
+        * `queue` - The task queue
+        * `signal_name` - The name of the signal
+        * `signal_value` - Serialized signal value (JSON bytes)
+
+        # Returns
+        Information about whether the workflow was created and the signal event sequence.
+        """
+
+        raise NotImplementedError
+    def signal_workflow(self, workflow_execution_id: "str",signal_name: "str",signal_value: "bytes"):
+        """
+        Send a signal to an existing workflow.
+
+        # Arguments
+        * `workflow_execution_id` - The workflow execution ID
+        * `signal_name` - The name of the signal
+        * `signal_value` - Serialized signal value (JSON bytes)
+
+        # Returns
+        The sequence number of the signal event.
+        """
+
+        raise NotImplementedError
     def start_workflow(self, workflow_kind: "str",input: "bytes",queue: "typing.Optional[str]",workflow_version: "typing.Optional[str]",idempotency_key: "typing.Optional[str]"):
         """
         Start a new workflow execution.
@@ -1902,6 +2006,82 @@ class CoreClient:
         _UniffiConverterString.lower(promise_id),
         _UniffiConverterBytes.lower(value))
 
+
+
+
+
+
+    def signal_with_start_workflow(self, workflow_id: "str",workflow_kind: "str",workflow_input: "bytes",queue: "typing.Optional[str]",signal_name: "str",signal_value: "bytes") -> "SignalWithStartResponse":
+        """
+        Send a signal to an existing workflow, or create a new workflow and send the signal.
+
+        This is an atomic operation - either the workflow exists and receives the signal,
+        or a new workflow is created with the signal. This prevents race conditions
+        where a workflow might be created between checking for existence and signaling.
+
+        # Arguments
+        * `workflow_id` - The workflow ID (used as idempotency key)
+        * `workflow_kind` - The type/kind of workflow to create if it doesn't exist
+        * `workflow_input` - Serialized input for the workflow (JSON bytes)
+        * `queue` - The task queue
+        * `signal_name` - The name of the signal
+        * `signal_value` - Serialized signal value (JSON bytes)
+
+        # Returns
+        Information about whether the workflow was created and the signal event sequence.
+        """
+
+        _UniffiConverterString.check_lower(workflow_id)
+        
+        _UniffiConverterString.check_lower(workflow_kind)
+        
+        _UniffiConverterBytes.check_lower(workflow_input)
+        
+        _UniffiConverterOptionalString.check_lower(queue)
+        
+        _UniffiConverterString.check_lower(signal_name)
+        
+        _UniffiConverterBytes.check_lower(signal_value)
+        
+        return _UniffiConverterTypeSignalWithStartResponse.lift(
+            _uniffi_rust_call_with_error(_UniffiConverterTypeFfiError,_UniffiLib.uniffi_flovyn_worker_ffi_fn_method_coreclient_signal_with_start_workflow,self._uniffi_clone_pointer(),
+        _UniffiConverterString.lower(workflow_id),
+        _UniffiConverterString.lower(workflow_kind),
+        _UniffiConverterBytes.lower(workflow_input),
+        _UniffiConverterOptionalString.lower(queue),
+        _UniffiConverterString.lower(signal_name),
+        _UniffiConverterBytes.lower(signal_value))
+        )
+
+
+
+
+
+    def signal_workflow(self, workflow_execution_id: "str",signal_name: "str",signal_value: "bytes") -> "SignalWorkflowResponse":
+        """
+        Send a signal to an existing workflow.
+
+        # Arguments
+        * `workflow_execution_id` - The workflow execution ID
+        * `signal_name` - The name of the signal
+        * `signal_value` - Serialized signal value (JSON bytes)
+
+        # Returns
+        The sequence number of the signal event.
+        """
+
+        _UniffiConverterString.check_lower(workflow_execution_id)
+        
+        _UniffiConverterString.check_lower(signal_name)
+        
+        _UniffiConverterBytes.check_lower(signal_value)
+        
+        return _UniffiConverterTypeSignalWorkflowResponse.lift(
+            _uniffi_rust_call_with_error(_UniffiConverterTypeFfiError,_UniffiLib.uniffi_flovyn_worker_ffi_fn_method_coreclient_signal_workflow,self._uniffi_clone_pointer(),
+        _UniffiConverterString.lower(workflow_execution_id),
+        _UniffiConverterString.lower(signal_name),
+        _UniffiConverterBytes.lower(signal_value))
+        )
 
 
 
@@ -3021,15 +3201,33 @@ class FfiWorkflowContextProtocol(typing.Protocol):
         """
 
         raise NotImplementedError
+    def drain_signals(self, ):
+        """
+        Drain all pending signals from the queue.
+        """
+
+        raise NotImplementedError
     def get_state(self, key: "str"):
         """
         Get workflow state.
         """
 
         raise NotImplementedError
+    def has_signal(self, ):
+        """
+        Check if any signals are pending in the queue.
+        """
+
+        raise NotImplementedError
     def is_cancellation_requested(self, ):
         """
         Check if cancellation has been requested.
+        """
+
+        raise NotImplementedError
+    def pending_signal_count(self, ):
+        """
+        Get the number of pending signals.
         """
 
         raise NotImplementedError
@@ -3118,6 +3316,16 @@ class FfiWorkflowContextProtocol(typing.Protocol):
         Take all generated commands (only new ones, not replayed).
 
         This drains the command buffer and returns the commands.
+        """
+
+        raise NotImplementedError
+    def wait_for_signal(self, ):
+        """
+        Wait for the next signal in the queue.
+
+        Returns:
+        - `Received` if a signal is available
+        - `Pending` if no signal available - workflow should suspend
         """
 
         raise NotImplementedError
@@ -3246,6 +3454,19 @@ class FfiWorkflowContext:
 
 
 
+    def drain_signals(self, ) -> "typing.List[FfiSignalEvent]":
+        """
+        Drain all pending signals from the queue.
+        """
+
+        return _UniffiConverterSequenceTypeFfiSignalEvent.lift(
+            _uniffi_rust_call(_UniffiLib.uniffi_flovyn_worker_ffi_fn_method_ffiworkflowcontext_drain_signals,self._uniffi_clone_pointer(),)
+        )
+
+
+
+
+
     def get_state(self, key: "str") -> "typing.Optional[bytes]":
         """
         Get workflow state.
@@ -3262,6 +3483,19 @@ class FfiWorkflowContext:
 
 
 
+    def has_signal(self, ) -> "bool":
+        """
+        Check if any signals are pending in the queue.
+        """
+
+        return _UniffiConverterBool.lift(
+            _uniffi_rust_call(_UniffiLib.uniffi_flovyn_worker_ffi_fn_method_ffiworkflowcontext_has_signal,self._uniffi_clone_pointer(),)
+        )
+
+
+
+
+
     def is_cancellation_requested(self, ) -> "bool":
         """
         Check if cancellation has been requested.
@@ -3269,6 +3503,19 @@ class FfiWorkflowContext:
 
         return _UniffiConverterBool.lift(
             _uniffi_rust_call(_UniffiLib.uniffi_flovyn_worker_ffi_fn_method_ffiworkflowcontext_is_cancellation_requested,self._uniffi_clone_pointer(),)
+        )
+
+
+
+
+
+    def pending_signal_count(self, ) -> "int":
+        """
+        Get the number of pending signals.
+        """
+
+        return _UniffiConverterUInt32.lift(
+            _uniffi_rust_call(_UniffiLib.uniffi_flovyn_worker_ffi_fn_method_ffiworkflowcontext_pending_signal_count,self._uniffi_clone_pointer(),)
         )
 
 
@@ -3476,6 +3723,23 @@ class FfiWorkflowContext:
 
         return _UniffiConverterSequenceTypeFfiWorkflowCommand.lift(
             _uniffi_rust_call(_UniffiLib.uniffi_flovyn_worker_ffi_fn_method_ffiworkflowcontext_take_commands,self._uniffi_clone_pointer(),)
+        )
+
+
+
+
+
+    def wait_for_signal(self, ) -> "FfiSignalResult":
+        """
+        Wait for the next signal in the queue.
+
+        Returns:
+        - `Received` if a signal is available
+        - `Pending` if no signal available - workflow should suspend
+        """
+
+        return _UniffiConverterTypeFfiSignalResult.lift(
+            _uniffi_rust_call(_UniffiLib.uniffi_flovyn_worker_ffi_fn_method_ffiworkflowcontext_wait_for_signal,self._uniffi_clone_pointer(),)
         )
 
 
@@ -3852,6 +4116,54 @@ class _UniffiConverterTypeFfiReplayEvent(_UniffiConverterRustBuffer):
         _UniffiConverterInt64.write(value.timestamp_ms, buf)
 
 
+class FfiSignalEvent:
+    """
+    A signal event from the signal queue.
+    """
+
+    signal_name: "str"
+    """
+    Signal name.
+    """
+
+    value: "bytes"
+    """
+    Serialized value as JSON bytes.
+    """
+
+    def __init__(self, *, signal_name: "str", value: "bytes"):
+        self.signal_name = signal_name
+        self.value = value
+
+    def __str__(self):
+        return "FfiSignalEvent(signal_name={}, value={})".format(self.signal_name, self.value)
+
+    def __eq__(self, other):
+        if self.signal_name != other.signal_name:
+            return False
+        if self.value != other.value:
+            return False
+        return True
+
+class _UniffiConverterTypeFfiSignalEvent(_UniffiConverterRustBuffer):
+    @staticmethod
+    def read(buf):
+        return FfiSignalEvent(
+            signal_name=_UniffiConverterString.read(buf),
+            value=_UniffiConverterBytes.read(buf),
+        )
+
+    @staticmethod
+    def check_lower(value):
+        _UniffiConverterString.check_lower(value.signal_name)
+        _UniffiConverterBytes.check_lower(value.value)
+
+    @staticmethod
+    def write(value, buf):
+        _UniffiConverterString.write(value.signal_name, buf)
+        _UniffiConverterBytes.write(value.value, buf)
+
+
 class LifecycleEvent:
     """
     Lifecycle event for worker status changes.
@@ -3979,6 +4291,102 @@ class _UniffiConverterTypeOAuth2Credentials(_UniffiConverterRustBuffer):
         _UniffiConverterString.write(value.client_secret, buf)
         _UniffiConverterString.write(value.token_endpoint, buf)
         _UniffiConverterOptionalString.write(value.scopes, buf)
+
+
+class SignalWithStartResponse:
+    """
+    Result of signal-with-start operation.
+    """
+
+    workflow_execution_id: "str"
+    """
+    The workflow execution ID.
+    """
+
+    workflow_created: "bool"
+    """
+    Whether the workflow was created (vs already existed).
+    """
+
+    signal_event_sequence: "int"
+    """
+    Sequence number of the signal event.
+    """
+
+    def __init__(self, *, workflow_execution_id: "str", workflow_created: "bool", signal_event_sequence: "int"):
+        self.workflow_execution_id = workflow_execution_id
+        self.workflow_created = workflow_created
+        self.signal_event_sequence = signal_event_sequence
+
+    def __str__(self):
+        return "SignalWithStartResponse(workflow_execution_id={}, workflow_created={}, signal_event_sequence={})".format(self.workflow_execution_id, self.workflow_created, self.signal_event_sequence)
+
+    def __eq__(self, other):
+        if self.workflow_execution_id != other.workflow_execution_id:
+            return False
+        if self.workflow_created != other.workflow_created:
+            return False
+        if self.signal_event_sequence != other.signal_event_sequence:
+            return False
+        return True
+
+class _UniffiConverterTypeSignalWithStartResponse(_UniffiConverterRustBuffer):
+    @staticmethod
+    def read(buf):
+        return SignalWithStartResponse(
+            workflow_execution_id=_UniffiConverterString.read(buf),
+            workflow_created=_UniffiConverterBool.read(buf),
+            signal_event_sequence=_UniffiConverterInt64.read(buf),
+        )
+
+    @staticmethod
+    def check_lower(value):
+        _UniffiConverterString.check_lower(value.workflow_execution_id)
+        _UniffiConverterBool.check_lower(value.workflow_created)
+        _UniffiConverterInt64.check_lower(value.signal_event_sequence)
+
+    @staticmethod
+    def write(value, buf):
+        _UniffiConverterString.write(value.workflow_execution_id, buf)
+        _UniffiConverterBool.write(value.workflow_created, buf)
+        _UniffiConverterInt64.write(value.signal_event_sequence, buf)
+
+
+class SignalWorkflowResponse:
+    """
+    Result of signaling a workflow.
+    """
+
+    signal_event_sequence: "int"
+    """
+    Sequence number of the signal event.
+    """
+
+    def __init__(self, *, signal_event_sequence: "int"):
+        self.signal_event_sequence = signal_event_sequence
+
+    def __str__(self):
+        return "SignalWorkflowResponse(signal_event_sequence={})".format(self.signal_event_sequence)
+
+    def __eq__(self, other):
+        if self.signal_event_sequence != other.signal_event_sequence:
+            return False
+        return True
+
+class _UniffiConverterTypeSignalWorkflowResponse(_UniffiConverterRustBuffer):
+    @staticmethod
+    def read(buf):
+        return SignalWorkflowResponse(
+            signal_event_sequence=_UniffiConverterInt64.read(buf),
+        )
+
+    @staticmethod
+    def check_lower(value):
+        _UniffiConverterInt64.check_lower(value.signal_event_sequence)
+
+    @staticmethod
+    def write(value, buf):
+        _UniffiConverterInt64.write(value.signal_event_sequence, buf)
 
 
 class StartWorkflowResponse:
@@ -5328,6 +5736,8 @@ class FfiEventType(enum.Enum):
     
     TIMER_CANCELLED = 23
     
+    SIGNAL_RECEIVED = 24
+    
 
 
 class _UniffiConverterTypeFfiEventType(_UniffiConverterRustBuffer):
@@ -5382,6 +5792,8 @@ class _UniffiConverterTypeFfiEventType(_UniffiConverterRustBuffer):
             return FfiEventType.TIMER_FIRED
         if variant == 24:
             return FfiEventType.TIMER_CANCELLED
+        if variant == 25:
+            return FfiEventType.SIGNAL_RECEIVED
         raise InternalError("Raw enum value doesn't match any cases")
 
     @staticmethod
@@ -5433,6 +5845,8 @@ class _UniffiConverterTypeFfiEventType(_UniffiConverterRustBuffer):
         if value == FfiEventType.TIMER_FIRED:
             return
         if value == FfiEventType.TIMER_CANCELLED:
+            return
+        if value == FfiEventType.SIGNAL_RECEIVED:
             return
         raise ValueError(value)
 
@@ -5486,6 +5900,8 @@ class _UniffiConverterTypeFfiEventType(_UniffiConverterRustBuffer):
             buf.write_i32(23)
         if value == FfiEventType.TIMER_CANCELLED:
             buf.write_i32(24)
+        if value == FfiEventType.SIGNAL_RECEIVED:
+            buf.write_i32(25)
 
 
 
@@ -5780,6 +6196,122 @@ class _UniffiConverterTypeFfiPromiseResult(_UniffiConverterRustBuffer):
         if value.is_pending():
             buf.write_i32(4)
             _UniffiConverterString.write(value.promise_id, buf)
+
+
+
+
+
+
+
+class FfiSignalResult:
+    """
+    Result of waiting for a signal.
+    """
+
+    def __init__(self):
+        raise RuntimeError("FfiSignalResult cannot be instantiated directly")
+
+    # Each enum variant is a nested class of the enum itself.
+    class RECEIVED:
+        """
+        Signal received - return the signal data.
+        """
+
+        signal_name: "str"
+        """
+        Signal name.
+        """
+
+        value: "bytes"
+        """
+        Serialized value as JSON bytes.
+        """
+
+
+        def __init__(self,signal_name: "str", value: "bytes"):
+            self.signal_name = signal_name
+            self.value = value
+
+        def __str__(self):
+            return "FfiSignalResult.RECEIVED(signal_name={}, value={})".format(self.signal_name, self.value)
+
+        def __eq__(self, other):
+            if not other.is_received():
+                return False
+            if self.signal_name != other.signal_name:
+                return False
+            if self.value != other.value:
+                return False
+            return True
+    
+    class PENDING:
+        """
+        No signal available - workflow should suspend.
+        """
+
+
+        def __init__(self,):
+            pass
+
+        def __str__(self):
+            return "FfiSignalResult.PENDING()".format()
+
+        def __eq__(self, other):
+            if not other.is_pending():
+                return False
+            return True
+    
+    
+
+    # For each variant, we have an `is_NAME` method for easily checking
+    # whether an instance is that variant.
+    def is_received(self) -> bool:
+        return isinstance(self, FfiSignalResult.RECEIVED)
+    def is_pending(self) -> bool:
+        return isinstance(self, FfiSignalResult.PENDING)
+    
+
+# Now, a little trick - we make each nested variant class be a subclass of the main
+# enum class, so that method calls and instance checks etc will work intuitively.
+# We might be able to do this a little more neatly with a metaclass, but this'll do.
+FfiSignalResult.RECEIVED = type("FfiSignalResult.RECEIVED", (FfiSignalResult.RECEIVED, FfiSignalResult,), {})  # type: ignore
+FfiSignalResult.PENDING = type("FfiSignalResult.PENDING", (FfiSignalResult.PENDING, FfiSignalResult,), {})  # type: ignore
+
+
+
+
+class _UniffiConverterTypeFfiSignalResult(_UniffiConverterRustBuffer):
+    @staticmethod
+    def read(buf):
+        variant = buf.read_i32()
+        if variant == 1:
+            return FfiSignalResult.RECEIVED(
+                _UniffiConverterString.read(buf),
+                _UniffiConverterBytes.read(buf),
+            )
+        if variant == 2:
+            return FfiSignalResult.PENDING(
+            )
+        raise InternalError("Raw enum value doesn't match any cases")
+
+    @staticmethod
+    def check_lower(value):
+        if value.is_received():
+            _UniffiConverterString.check_lower(value.signal_name)
+            _UniffiConverterBytes.check_lower(value.value)
+            return
+        if value.is_pending():
+            return
+        raise ValueError(value)
+
+    @staticmethod
+    def write(value, buf):
+        if value.is_received():
+            buf.write_i32(1)
+            _UniffiConverterString.write(value.signal_name, buf)
+            _UniffiConverterBytes.write(value.value, buf)
+        if value.is_pending():
+            buf.write_i32(2)
 
 
 
@@ -8920,6 +9452,31 @@ class _UniffiConverterSequenceString(_UniffiConverterRustBuffer):
 
 
 
+class _UniffiConverterSequenceTypeFfiSignalEvent(_UniffiConverterRustBuffer):
+    @classmethod
+    def check_lower(cls, value):
+        for item in value:
+            _UniffiConverterTypeFfiSignalEvent.check_lower(item)
+
+    @classmethod
+    def write(cls, value, buf):
+        items = len(value)
+        buf.write_i32(items)
+        for item in value:
+            _UniffiConverterTypeFfiSignalEvent.write(item, buf)
+
+    @classmethod
+    def read(cls, buf):
+        count = buf.read_i32()
+        if count < 0:
+            raise InternalError("Unexpected negative sequence length")
+
+        return [
+            _UniffiConverterTypeFfiSignalEvent.read(buf) for i in range(count)
+        ]
+
+
+
 class _UniffiConverterSequenceTypeLifecycleEvent(_UniffiConverterRustBuffer):
     @classmethod
     def check_lower(cls, value):
@@ -9077,6 +9634,7 @@ __all__ = [
     "FfiEventType",
     "FfiOperationResult",
     "FfiPromiseResult",
+    "FfiSignalResult",
     "FfiStopReason",
     "FfiStreamEvent",
     "FfiTaskExecutionResult",
@@ -9091,8 +9649,11 @@ __all__ = [
     "FfiConnectionInfo",
     "FfiRegistrationInfo",
     "FfiReplayEvent",
+    "FfiSignalEvent",
     "LifecycleEvent",
     "OAuth2Credentials",
+    "SignalWithStartResponse",
+    "SignalWorkflowResponse",
     "StartWorkflowResponse",
     "StateEntry",
     "TaskActivation",

--- a/flovyn/_native/flovyn_worker_ffi.py
+++ b/flovyn/_native/flovyn_worker_ffi.py
@@ -556,15 +556,15 @@ def _uniffi_check_api_checksums(lib):
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_flovyn_worker_ffi_checksum_method_ffiworkflowcontext_current_time_millis() != 38125:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    if lib.uniffi_flovyn_worker_ffi_checksum_method_ffiworkflowcontext_drain_signals() != 26519:
+    if lib.uniffi_flovyn_worker_ffi_checksum_method_ffiworkflowcontext_drain_signals() != 12306:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_flovyn_worker_ffi_checksum_method_ffiworkflowcontext_get_state() != 9129:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    if lib.uniffi_flovyn_worker_ffi_checksum_method_ffiworkflowcontext_has_signal() != 27653:
+    if lib.uniffi_flovyn_worker_ffi_checksum_method_ffiworkflowcontext_has_signal() != 65034:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_flovyn_worker_ffi_checksum_method_ffiworkflowcontext_is_cancellation_requested() != 18572:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    if lib.uniffi_flovyn_worker_ffi_checksum_method_ffiworkflowcontext_pending_signal_count() != 13337:
+    if lib.uniffi_flovyn_worker_ffi_checksum_method_ffiworkflowcontext_pending_signal_count() != 57526:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_flovyn_worker_ffi_checksum_method_ffiworkflowcontext_random() != 22015:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
@@ -588,7 +588,7 @@ def _uniffi_check_api_checksums(lib):
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_flovyn_worker_ffi_checksum_method_ffiworkflowcontext_take_commands() != 63915:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    if lib.uniffi_flovyn_worker_ffi_checksum_method_ffiworkflowcontext_wait_for_signal() != 4847:
+    if lib.uniffi_flovyn_worker_ffi_checksum_method_ffiworkflowcontext_wait_for_signal() != 7519:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_flovyn_worker_ffi_checksum_method_ffiworkflowcontext_workflow_execution_id() != 54462:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
@@ -1030,6 +1030,7 @@ _UniffiLib.uniffi_flovyn_worker_ffi_fn_method_ffiworkflowcontext_current_time_mi
 _UniffiLib.uniffi_flovyn_worker_ffi_fn_method_ffiworkflowcontext_current_time_millis.restype = ctypes.c_int64
 _UniffiLib.uniffi_flovyn_worker_ffi_fn_method_ffiworkflowcontext_drain_signals.argtypes = (
     ctypes.c_void_p,
+    _UniffiRustBuffer,
     ctypes.POINTER(_UniffiRustCallStatus),
 )
 _UniffiLib.uniffi_flovyn_worker_ffi_fn_method_ffiworkflowcontext_drain_signals.restype = _UniffiRustBuffer
@@ -1041,6 +1042,7 @@ _UniffiLib.uniffi_flovyn_worker_ffi_fn_method_ffiworkflowcontext_get_state.argty
 _UniffiLib.uniffi_flovyn_worker_ffi_fn_method_ffiworkflowcontext_get_state.restype = _UniffiRustBuffer
 _UniffiLib.uniffi_flovyn_worker_ffi_fn_method_ffiworkflowcontext_has_signal.argtypes = (
     ctypes.c_void_p,
+    _UniffiRustBuffer,
     ctypes.POINTER(_UniffiRustCallStatus),
 )
 _UniffiLib.uniffi_flovyn_worker_ffi_fn_method_ffiworkflowcontext_has_signal.restype = ctypes.c_int8
@@ -1051,6 +1053,7 @@ _UniffiLib.uniffi_flovyn_worker_ffi_fn_method_ffiworkflowcontext_is_cancellation
 _UniffiLib.uniffi_flovyn_worker_ffi_fn_method_ffiworkflowcontext_is_cancellation_requested.restype = ctypes.c_int8
 _UniffiLib.uniffi_flovyn_worker_ffi_fn_method_ffiworkflowcontext_pending_signal_count.argtypes = (
     ctypes.c_void_p,
+    _UniffiRustBuffer,
     ctypes.POINTER(_UniffiRustCallStatus),
 )
 _UniffiLib.uniffi_flovyn_worker_ffi_fn_method_ffiworkflowcontext_pending_signal_count.restype = ctypes.c_uint32
@@ -1126,6 +1129,7 @@ _UniffiLib.uniffi_flovyn_worker_ffi_fn_method_ffiworkflowcontext_take_commands.a
 _UniffiLib.uniffi_flovyn_worker_ffi_fn_method_ffiworkflowcontext_take_commands.restype = _UniffiRustBuffer
 _UniffiLib.uniffi_flovyn_worker_ffi_fn_method_ffiworkflowcontext_wait_for_signal.argtypes = (
     ctypes.c_void_p,
+    _UniffiRustBuffer,
     ctypes.POINTER(_UniffiRustCallStatus),
 )
 _UniffiLib.uniffi_flovyn_worker_ffi_fn_method_ffiworkflowcontext_wait_for_signal.restype = _UniffiRustBuffer
@@ -3201,9 +3205,9 @@ class FfiWorkflowContextProtocol(typing.Protocol):
         """
 
         raise NotImplementedError
-    def drain_signals(self, ):
+    def drain_signals(self, signal_name: "str"):
         """
-        Drain all pending signals from the queue.
+        Drain all pending signals with the specified name.
         """
 
         raise NotImplementedError
@@ -3213,9 +3217,9 @@ class FfiWorkflowContextProtocol(typing.Protocol):
         """
 
         raise NotImplementedError
-    def has_signal(self, ):
+    def has_signal(self, signal_name: "str"):
         """
-        Check if any signals are pending in the queue.
+        Check if any signals with the specified name are pending.
         """
 
         raise NotImplementedError
@@ -3225,9 +3229,9 @@ class FfiWorkflowContextProtocol(typing.Protocol):
         """
 
         raise NotImplementedError
-    def pending_signal_count(self, ):
+    def pending_signal_count(self, signal_name: "str"):
         """
-        Get the number of pending signals.
+        Get the number of pending signals with the specified name.
         """
 
         raise NotImplementedError
@@ -3319,13 +3323,15 @@ class FfiWorkflowContextProtocol(typing.Protocol):
         """
 
         raise NotImplementedError
-    def wait_for_signal(self, ):
+    def wait_for_signal(self, signal_name: "str"):
         """
-        Wait for the next signal in the queue.
+        Wait for the next signal with the specified name.
+
+        Each signal name has its own FIFO queue.
 
         Returns:
-        - `Received` if a signal is available
-        - `Pending` if no signal available - workflow should suspend
+        - `Received` if a signal with the given name is available
+        - `Pending` if no signal with that name available - workflow should suspend
         """
 
         raise NotImplementedError
@@ -3454,13 +3460,16 @@ class FfiWorkflowContext:
 
 
 
-    def drain_signals(self, ) -> "typing.List[FfiSignalEvent]":
+    def drain_signals(self, signal_name: "str") -> "typing.List[FfiSignalEvent]":
         """
-        Drain all pending signals from the queue.
+        Drain all pending signals with the specified name.
         """
 
+        _UniffiConverterString.check_lower(signal_name)
+        
         return _UniffiConverterSequenceTypeFfiSignalEvent.lift(
-            _uniffi_rust_call(_UniffiLib.uniffi_flovyn_worker_ffi_fn_method_ffiworkflowcontext_drain_signals,self._uniffi_clone_pointer(),)
+            _uniffi_rust_call(_UniffiLib.uniffi_flovyn_worker_ffi_fn_method_ffiworkflowcontext_drain_signals,self._uniffi_clone_pointer(),
+        _UniffiConverterString.lower(signal_name))
         )
 
 
@@ -3483,13 +3492,16 @@ class FfiWorkflowContext:
 
 
 
-    def has_signal(self, ) -> "bool":
+    def has_signal(self, signal_name: "str") -> "bool":
         """
-        Check if any signals are pending in the queue.
+        Check if any signals with the specified name are pending.
         """
 
+        _UniffiConverterString.check_lower(signal_name)
+        
         return _UniffiConverterBool.lift(
-            _uniffi_rust_call(_UniffiLib.uniffi_flovyn_worker_ffi_fn_method_ffiworkflowcontext_has_signal,self._uniffi_clone_pointer(),)
+            _uniffi_rust_call(_UniffiLib.uniffi_flovyn_worker_ffi_fn_method_ffiworkflowcontext_has_signal,self._uniffi_clone_pointer(),
+        _UniffiConverterString.lower(signal_name))
         )
 
 
@@ -3509,13 +3521,16 @@ class FfiWorkflowContext:
 
 
 
-    def pending_signal_count(self, ) -> "int":
+    def pending_signal_count(self, signal_name: "str") -> "int":
         """
-        Get the number of pending signals.
+        Get the number of pending signals with the specified name.
         """
 
+        _UniffiConverterString.check_lower(signal_name)
+        
         return _UniffiConverterUInt32.lift(
-            _uniffi_rust_call(_UniffiLib.uniffi_flovyn_worker_ffi_fn_method_ffiworkflowcontext_pending_signal_count,self._uniffi_clone_pointer(),)
+            _uniffi_rust_call(_UniffiLib.uniffi_flovyn_worker_ffi_fn_method_ffiworkflowcontext_pending_signal_count,self._uniffi_clone_pointer(),
+        _UniffiConverterString.lower(signal_name))
         )
 
 
@@ -3729,17 +3744,22 @@ class FfiWorkflowContext:
 
 
 
-    def wait_for_signal(self, ) -> "FfiSignalResult":
+    def wait_for_signal(self, signal_name: "str") -> "FfiSignalResult":
         """
-        Wait for the next signal in the queue.
+        Wait for the next signal with the specified name.
+
+        Each signal name has its own FIFO queue.
 
         Returns:
-        - `Received` if a signal is available
-        - `Pending` if no signal available - workflow should suspend
+        - `Received` if a signal with the given name is available
+        - `Pending` if no signal with that name available - workflow should suspend
         """
 
+        _UniffiConverterString.check_lower(signal_name)
+        
         return _UniffiConverterTypeFfiSignalResult.lift(
-            _uniffi_rust_call(_UniffiLib.uniffi_flovyn_worker_ffi_fn_method_ffiworkflowcontext_wait_for_signal,self._uniffi_clone_pointer(),)
+            _uniffi_rust_call(_UniffiLib.uniffi_flovyn_worker_ffi_fn_method_ffiworkflowcontext_wait_for_signal,self._uniffi_clone_pointer(),
+        _UniffiConverterString.lower(signal_name))
         )
 
 

--- a/flovyn/context.py
+++ b/flovyn/context.py
@@ -1054,10 +1054,7 @@ class WorkflowContextImpl(WorkflowContext):
             A list of signal payloads.
         """
         ffi_signals = self._ffi.drain_signals(name)
-        return [
-            self._serializer.deserialize(bytes(sig.value), type_hint)
-            for sig in ffi_signals
-        ]
+        return [self._serializer.deserialize(bytes(sig.value), type_hint) for sig in ffi_signals]
 
     async def get(
         self,

--- a/flovyn/testing/environment.py
+++ b/flovyn/testing/environment.py
@@ -660,9 +660,7 @@ class TestHarness:
         logger.info(f"Created config file at {config_path}")
 
         # Start Flovyn server
-        server_image = os.environ.get(
-            "FLOVYN_SERVER_IMAGE", "rg.fr-par.scw.cloud/flovyn/flovyn-server:latest"
-        )
+        server_image = "rg.fr-par.scw.cloud/flovyn/flovyn-server:latest"
 
         self._server_container = DockerContainer(server_image)
         self._server_container.with_exposed_ports(8000, 9090)

--- a/flovyn/testing/environment.py
+++ b/flovyn/testing/environment.py
@@ -301,6 +301,65 @@ class FlovynTestEnvironment:
             error=error,
         )
 
+    async def signal_workflow(
+        self,
+        handle: WorkflowHandle[Any],
+        signal_name: str,
+        value: Any,
+    ) -> int:
+        """Send a signal to a running workflow.
+
+        Args:
+            handle: The workflow handle.
+            signal_name: The name of the signal.
+            value: The signal payload.
+
+        Returns:
+            The sequence number of the signal event.
+        """
+        if not self._started or self._client is None:
+            raise RuntimeError("Test environment not started. Call start() first.")
+
+        return await self._client.signal_workflow(
+            workflow_execution_id=handle.workflow_execution_id,
+            signal_name=signal_name,
+            value=value,
+        )
+
+    async def signal_with_start_workflow(
+        self,
+        workflow: str | type[Any],
+        workflow_id: str,
+        input: Any,
+        signal_name: str,
+        signal_value: Any,
+    ) -> WorkflowHandle[Any]:
+        """Send a signal to an existing workflow, or create a new workflow and send the signal.
+
+        This is an atomic operation - either the workflow exists and receives the signal,
+        or a new workflow is created with the signal.
+
+        Args:
+            workflow: The workflow kind (string) or workflow class.
+            workflow_id: The workflow ID (used as idempotency key).
+            input: The workflow input.
+            signal_name: The name of the signal.
+            signal_value: The signal payload.
+
+        Returns:
+            A handle to the workflow.
+        """
+        if not self._started or self._client is None:
+            raise RuntimeError("Test environment not started. Call start() first.")
+
+        return await self._client.signal_with_start_workflow(
+            workflow=workflow,
+            workflow_id=workflow_id,
+            input=input,
+            signal_name=signal_name,
+            signal_value=signal_value,
+        )
+
     @property
     def client(self) -> FlovynClient | None:
         """Get the underlying FlovynClient."""

--- a/flovyn/types.py
+++ b/flovyn/types.py
@@ -37,6 +37,7 @@ class StreamEvent:
     data: Any
     timestamp: int
 
+
 # Type variables for generics
 InputT = TypeVar("InputT", contravariant=True)
 OutputT = TypeVar("OutputT", covariant=True)

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -57,17 +57,20 @@ async def env(test_harness) -> AsyncGenerator[FlovynTestEnvironment, None]:
         ChildWorkflowWorkflow,
         ComprehensiveWorkflow,
         DoublerWorkflow,
+        DrainSignalsWorkflow,
         EchoWorkflow,
         FailingWorkflow,
         FanOutFanInWorkflow,
         LargeBatchWorkflow,
         MixedCommandsWorkflow,
         MixedParallelWorkflow,
+        MultiSignalWorkflow,
         MultiTaskWorkflow,
         NestedChildWorkflow,
         ParallelTasksWorkflow,
         RandomWorkflow,
         RunOperationWorkflow,
+        SignalWorkflow,
         SleepWorkflow,
         StatefulWorkflow,
         TaskSchedulerWorkflow,
@@ -102,6 +105,9 @@ async def env(test_harness) -> AsyncGenerator[FlovynTestEnvironment, None]:
     environment.register_workflow(ComprehensiveWorkflow)
     environment.register_workflow(TaskSchedulerWorkflow)
     environment.register_workflow(TypedTaskWorkflow)
+    environment.register_workflow(SignalWorkflow)
+    environment.register_workflow(MultiSignalWorkflow)
+    environment.register_workflow(DrainSignalsWorkflow)
 
     # Register all tasks
     environment.register_task(EchoTask)

--- a/tests/e2e/fixtures/workflows.py
+++ b/tests/e2e/fixtures/workflows.py
@@ -760,8 +760,8 @@ class SignalWorkflow:
     """
 
     async def run(self, ctx: WorkflowContext, input: SignalInput) -> SignalOutput:
-        # Wait for a single signal
-        signal_value = await ctx.wait_for_signal()
+        # Wait for a single signal with the well-known name 'signal'
+        signal_value = await ctx.wait_for_signal("signal")
 
         return SignalOutput(
             received_signals=[signal_value],
@@ -789,8 +789,8 @@ class MultiSignalWorkflow:
         received = []
 
         for _ in range(input.expected_count):
-            # Wait for each signal
-            signal_value = await ctx.wait_for_signal()
+            # Wait for each signal with the well-known name 'message'
+            signal_value = await ctx.wait_for_signal("message")
             received.append(signal_value)
 
         return MultiSignalOutput(

--- a/tests/e2e/fixtures/workflows.py
+++ b/tests/e2e/fixtures/workflows.py
@@ -738,6 +738,99 @@ class TypedTaskOutput(BaseModel):
     result: int
 
 
+# ============================================================================
+# Signal Workflows
+# ============================================================================
+
+
+class SignalInput(BaseModel):
+    pass
+
+
+class SignalOutput(BaseModel):
+    received_signals: list[Any]
+    signal_count: int
+
+
+@workflow(name="signal-workflow")
+class SignalWorkflow:
+    """Workflow that waits for a signal and returns the value.
+
+    Used for testing signal functionality.
+    """
+
+    async def run(self, ctx: WorkflowContext, input: SignalInput) -> SignalOutput:
+        # Wait for a single signal
+        signal_value = await ctx.wait_for_signal()
+
+        return SignalOutput(
+            received_signals=[signal_value],
+            signal_count=1,
+        )
+
+
+class MultiSignalInput(BaseModel):
+    expected_count: int
+
+
+class MultiSignalOutput(BaseModel):
+    received_signals: list[Any]
+    signal_count: int
+
+
+@workflow(name="multi-signal-workflow")
+class MultiSignalWorkflow:
+    """Workflow that waits for multiple signals.
+
+    Used for testing multiple signal delivery and ordering.
+    """
+
+    async def run(self, ctx: WorkflowContext, input: MultiSignalInput) -> MultiSignalOutput:
+        received = []
+
+        for _ in range(input.expected_count):
+            # Wait for each signal
+            signal_value = await ctx.wait_for_signal()
+            received.append(signal_value)
+
+        return MultiSignalOutput(
+            received_signals=received,
+            signal_count=len(received),
+        )
+
+
+class DrainSignalsInput(BaseModel):
+    pass
+
+
+class DrainSignalsOutput(BaseModel):
+    had_signals: bool
+    signal_count: int
+    drained_values: list[Any]
+
+
+@workflow(name="drain-signals-workflow")
+class DrainSignalsWorkflow:
+    """Workflow that drains all signals from the queue.
+
+    Used for testing has_signal() and drain_signals() APIs.
+    """
+
+    async def run(self, ctx: WorkflowContext, input: DrainSignalsInput) -> DrainSignalsOutput:
+        # Check if signals are available
+        had_signals = ctx.has_signal()
+        count = ctx.pending_signal_count()
+
+        # Drain all signals
+        values = ctx.drain_signals()
+
+        return DrainSignalsOutput(
+            had_signals=had_signals,
+            signal_count=count,
+            drained_values=values,
+        )
+
+
 @workflow(name="typed-task-workflow")
 class TypedTaskWorkflow:
     """Workflow that uses the typed API to execute a task.

--- a/tests/e2e/test_signal.py
+++ b/tests/e2e/test_signal.py
@@ -28,10 +28,10 @@ async def test_signal_workflow(env: FlovynTestEnvironment) -> None:
     # Wait for workflow to suspend and start waiting for signals
     await asyncio.sleep(2.0)
 
-    # Send signal externally
+    # Send signal externally (must use 'signal' name that workflow expects)
     await env.signal_workflow(
         handle,
-        "user-action",
+        "signal",
         {"action": "approve", "user": "admin@example.com"},
     )
 
@@ -63,10 +63,10 @@ async def test_multiple_signals(env: FlovynTestEnvironment) -> None:
     # Wait for workflow to start
     await asyncio.sleep(2.0)
 
-    # Send 3 signals
-    await env.signal_workflow(handle, "signal-1", {"order": 1})
-    await env.signal_workflow(handle, "signal-2", {"order": 2})
-    await env.signal_workflow(handle, "signal-3", {"order": 3})
+    # Send 3 signals (must use 'message' name that workflow expects)
+    await env.signal_workflow(handle, "message", {"order": 1})
+    await env.signal_workflow(handle, "message", {"order": 2})
+    await env.signal_workflow(handle, "message", {"order": 3})
 
     # Wait for workflow to complete
     result = await env.await_completion(handle, timeout=timedelta(seconds=30))
@@ -92,12 +92,12 @@ async def test_signal_with_start_new_workflow(env: FlovynTestEnvironment) -> Non
 
     workflow_id = f"signal-with-start-{uuid.uuid4().hex[:8]}"
 
-    # Use signal_with_start to create workflow with signal
+    # Use signal_with_start to create workflow with signal (must use 'signal' name)
     handle = await env.signal_with_start_workflow(
         "signal-workflow",
         workflow_id,
         {},  # Empty input
-        "init-signal",
+        "signal",
         {"data": "from signal_with_start"},
     )
 
@@ -135,16 +135,17 @@ async def test_signal_with_start_existing_workflow(env: FlovynTestEnvironment) -
     await asyncio.sleep(2.0)
 
     # Use signal_with_start on the same workflow ID - should only send signal
+    # Must use 'message' signal name that multi-signal-workflow expects
     await env.signal_with_start_workflow(
         "multi-signal-workflow",
         workflow_id,
         {"expected_count": 2},  # Would be different if workflow was recreated
-        "signal-via-sws",
+        "message",
         {"source": "signal_with_start"},
     )
 
-    # Send second signal to complete
-    await env.signal_workflow(handle, "second-signal", {"source": "direct"})
+    # Send second signal to complete (must use 'message' name)
+    await env.signal_workflow(handle, "message", {"source": "direct"})
 
     # Wait for workflow to complete
     result = await env.await_completion(handle, timeout=timedelta(seconds=30))

--- a/tests/e2e/test_signal.py
+++ b/tests/e2e/test_signal.py
@@ -1,0 +1,155 @@
+"""E2E tests for signal functionality."""
+
+import asyncio
+from datetime import timedelta
+
+import pytest
+
+from flovyn.testing import FlovynTestEnvironment
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_signal_workflow(env: FlovynTestEnvironment) -> None:
+    """Test external signal delivery.
+
+    Flow:
+    1. Start workflow that waits for a signal
+    2. Workflow suspends waiting for signal
+    3. Send signal externally
+    4. Workflow resumes and completes with the signal value
+    """
+    # Start the workflow (it will suspend waiting for the signal)
+    handle = await env.start_workflow(
+        "signal-workflow",
+        {},
+    )
+
+    # Wait for workflow to suspend and start waiting for signals
+    await asyncio.sleep(2.0)
+
+    # Send signal externally
+    await env.signal_workflow(
+        handle,
+        "user-action",
+        {"action": "approve", "user": "admin@example.com"},
+    )
+
+    # Wait for workflow to complete
+    result = await env.await_completion(handle, timeout=timedelta(seconds=30))
+
+    # Verify the signal value was received
+    assert result["signal_count"] == 1
+    assert len(result["received_signals"]) == 1
+    assert result["received_signals"][0] == {"action": "approve", "user": "admin@example.com"}
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_multiple_signals(env: FlovynTestEnvironment) -> None:
+    """Test multiple signals are delivered in order.
+
+    Flow:
+    1. Start workflow that waits for 3 signals
+    2. Send 3 signals
+    3. Workflow should receive them in order
+    """
+    # Start the workflow
+    handle = await env.start_workflow(
+        "multi-signal-workflow",
+        {"expected_count": 3},
+    )
+
+    # Wait for workflow to start
+    await asyncio.sleep(2.0)
+
+    # Send 3 signals
+    await env.signal_workflow(handle, "signal-1", {"order": 1})
+    await env.signal_workflow(handle, "signal-2", {"order": 2})
+    await env.signal_workflow(handle, "signal-3", {"order": 3})
+
+    # Wait for workflow to complete
+    result = await env.await_completion(handle, timeout=timedelta(seconds=30))
+
+    # Verify signals were received in order
+    assert result["signal_count"] == 3
+    assert len(result["received_signals"]) == 3
+    assert result["received_signals"][0] == {"order": 1}
+    assert result["received_signals"][1] == {"order": 2}
+    assert result["received_signals"][2] == {"order": 3}
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_signal_with_start_new_workflow(env: FlovynTestEnvironment) -> None:
+    """Test signal_with_start creates a new workflow with signal.
+
+    Flow:
+    1. Call signal_with_start on a workflow ID that doesn't exist
+    2. Workflow should be created and receive the signal
+    """
+    import uuid
+
+    workflow_id = f"signal-with-start-{uuid.uuid4().hex[:8]}"
+
+    # Use signal_with_start to create workflow with signal
+    handle = await env.signal_with_start_workflow(
+        "signal-workflow",
+        workflow_id,
+        {},  # Empty input
+        "init-signal",
+        {"data": "from signal_with_start"},
+    )
+
+    # Wait for workflow to complete
+    result = await env.await_completion(handle, timeout=timedelta(seconds=30))
+
+    # Verify signal was received
+    assert result["signal_count"] == 1
+    assert result["received_signals"][0] == {"data": "from signal_with_start"}
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_signal_with_start_existing_workflow(env: FlovynTestEnvironment) -> None:
+    """Test signal_with_start on existing workflow only sends signal.
+
+    Flow:
+    1. Start a workflow waiting for 2 signals
+    2. Call signal_with_start with same workflow ID
+    3. Workflow should receive only the signal (not be recreated)
+    4. Send second signal to complete
+    """
+    import uuid
+
+    workflow_id = f"signal-with-start-existing-{uuid.uuid4().hex[:8]}"
+
+    # First, start workflow waiting for 2 signals
+    handle = await env.start_workflow(
+        "multi-signal-workflow",
+        {"expected_count": 2},
+        workflow_id=workflow_id,
+    )
+
+    # Wait for workflow to start
+    await asyncio.sleep(2.0)
+
+    # Use signal_with_start on the same workflow ID - should only send signal
+    await env.signal_with_start_workflow(
+        "multi-signal-workflow",
+        workflow_id,
+        {"expected_count": 2},  # Would be different if workflow was recreated
+        "signal-via-sws",
+        {"source": "signal_with_start"},
+    )
+
+    # Send second signal to complete
+    await env.signal_workflow(handle, "second-signal", {"source": "direct"})
+
+    # Wait for workflow to complete
+    result = await env.await_completion(handle, timeout=timedelta(seconds=30))
+
+    # Verify both signals were received
+    assert result["signal_count"] == 2
+    assert {"source": "signal_with_start"} in result["received_signals"]
+    assert {"source": "direct"} in result["received_signals"]


### PR DESCRIPTION
Related to flovyn/flovyn/dev#10

## Summary

### Problem Statement
Currently, Flovyn cannot efficiently represent long-running conversations (like chatbot sessions) as workflows. The problem arises from two limitations:

1. **Start vs Signal Dilemma**: To send a message to a conversation, you need to either:
   - Start a new workflow (but this creates duplicates if one already exists)
   - Signal an existing workflow (but this fails if none exists yet)

2. **Race Condition with Idempotency Key**: Using idempotency keys helps with the first message, but creates a race condition for subsequent messages:
   ```
   Thread A: Start workflow with key="conv-123" → Creates workflow
   Thread B: Start workflow with key="conv-123" → Returns existing (good!)
   Thread B: Try to signal with message → Works
   Thread A: Try to signal with message → ??? (no guarantee of ordering)
   ```

3. **Two-Step Race**: Even if you check first, there's a window for failure:
   ```
   Thread A: Check if workflow exists? No → Start workflow
   Thread B: Check if workflow exists? No → Start workflow ← CONFLICT!
   ```

**Use Case: Chatbot Conversations**

A chatbot needs to:
1. Receive a user message for conversation ID "conv-123"
2. If no workflow exists for this conversation, start one
3. If a workflow already exists, send the message to it (signal)
4. The workflow processes messages sequentially

Without an atomic "start-or-signal" operation, this pattern is either racy or requires complex client-side coordination.

---

## Design Doc

See `docs/design/20260127_implement_signalwithstart.md` for detailed design.

## Test Plan

- [ ] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing completed

---

Generated with [Claude Code](https://claude.com/claude-code)
