### PR TITLE
Workspace Build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,38 +44,36 @@ jobs:
       - name: Run unit tests
         run: uv run pytest tests/unit -v --tb=short
 
-  e2e-test:
+  # E2E tests moved to workspace CI (dev repo)
+
+  trigger-workspace:
+    name: Trigger Workspace CI
     runs-on: ubuntu-latest
-    needs: build
-    timeout-minutes: 30
-    continue-on-error: true # E2E tests can be flaky, don't block the workflow
-
+    needs: [build]
+    if: github.event_name == 'push' && github.ref_name != 'main'
     steps:
-      - uses: actions/checkout@v4
+      - name: Check for matching branches
+        id: check
+        run: |
+          BRANCH="${GITHUB_REF_NAME}"
+          MATCHING_REPOS=""
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
+          for repo in flovyn-server sdk-rust sdk-kotlin sdk-typescript; do
+            if git ls-remote --exit-code --heads "https://github.com/flovyn/$repo" "$BRANCH" 2>/dev/null; then
+              MATCHING_REPOS="$MATCHING_REPOS $repo"
+            fi
+          done
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v4
+          if [ -n "$MATCHING_REPOS" ]; then
+            echo "trigger=true" >> $GITHUB_OUTPUT
+            echo "Found matching branches in:$MATCHING_REPOS"
+          else
+            echo "trigger=false" >> $GITHUB_OUTPUT
+          fi
 
-      - name: Download native libraries from sdk-rust release
-        run: ./bin/download-ffi.sh ${{ env.FFI_VERSION }} linux-x86_64
-
-      - name: Install dependencies
-        run: uv sync --all-extras
-
-      - name: Login to Scaleway Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: rg.fr-par.scw.cloud/flovyn
-          username: nologin
-          password: ${{ secrets.SCW_SECRET_KEY }}
-
-      - name: Pull Flovyn Server image
-        run: docker pull rg.fr-par.scw.cloud/flovyn/flovyn-server:latest
-
-      - name: Run E2E tests
-        run: uv run pytest tests/e2e -v --tb=short -m e2e
+      - name: Trigger workspace CI
+        if: steps.check.outputs.trigger == 'true'
+        run: |
+          gh workflow run integration.yml -R flovyn/dev -f branch="${GITHUB_REF_NAME}"
+        env:
+          GH_TOKEN: ${{ secrets.WORKSPACE_PAT }}


### PR DESCRIPTION
Related to flovyn/flovyn/dev#15

## Summary

### Problem Statement
When developing features that span multiple repositories, CI workflows fail due to circular dependencies between repos. The dependency graph:

```
                         flovyn-app
                              ↓ (E2E tests need Docker images)
                    flovyn-server
                    ↑ (integration tests)    ↓ (E2E tests need Docker image)
                         sdk-rust (core FFI)
                    ↑ (FFI bindings)
        ┌───────────┼───────────┐
   sdk-python   sdk-kotlin   sdk-typescript
        └───────────┼───────────┘
                    ↓ (E2E tests)
                flovyn-server Docker
```

**The core issue:** Each repo's CI tries to download released artifacts from other repos, but during cross-repo development, those releases don't exist yet.

## Design Doc

See `docs/design/20260205_workspace_build.md` for detailed design.

## Test Plan

- [ ] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing completed

---

Generated with [Claude Code](https://claude.com/claude-code)
